### PR TITLE
refactor task5

### DIFF
--- a/__tests__/task5-get-api-articles.test.js
+++ b/__tests__/task5-get-api-articles.test.js
@@ -10,15 +10,6 @@ beforeEach(() => {
 });
 
 describe("GET /api/articles", () => {
-  test("should return 404, with message indicating the route is not found", () => {
-    return request(app)
-      .get("/api/bad-route")
-      .expect(404)
-      .then(({ body }) => {
-        expect(body.msg).toBe("ROUTE NOT FOUND");
-      });
-  });
-
   test("should return a 200 status code, indicating the endpoint is accessible", () => {
     return request(app).get("/api/articles").expect(200);
   });
@@ -64,6 +55,16 @@ describe("GET /api/articles", () => {
       .get("/api/articles")
       .then(({ body }) => {
         expect(body).toBeSortedBy("created_at", { descending: true });
+      });
+  });
+
+  test("should not return the body key-value pair", () => {
+    return request(app)
+      .get("/api/articles")
+      .then(({ body }) => {
+        body.forEach((currentObj) => {
+          expect(currentObj).toEqual(expect.not.objectContaining({ body: expect.any(String) }));
+        });
       });
   });
 });

--- a/app.js
+++ b/app.js
@@ -87,4 +87,9 @@ add controller & model
 add jest-sorted for tests
 update endpoints.json
 update tasks.md
+
+// Refactor Task 5
+add tests to make sure the returning objects do not contain the key-value pair of body
+update article controller naming convention from result -> articles
+remove 404 tests for this task
 */

--- a/mvc/controllers/article.controller.js
+++ b/mvc/controllers/article.controller.js
@@ -10,8 +10,8 @@ exports.getArticleById = (request, response, next) => {
 
 exports.getArticles = (request, response, next) => {
   selectArticles()
-    .then((result) => {
-      response.status(200).send(result);
+    .then((articles) => {
+      response.status(200).send(articles);
     })
     .catch(next);
 };


### PR DESCRIPTION
Refactor Task 5
add tests to make sure the returning objects do not contain the key-value pair of body
update article controller naming convention from result -> articles
remove 404 tests for this task